### PR TITLE
New Project Dialog - Change order of items in the project list

### DIFF
--- a/src/components/topbar/index.js
+++ b/src/components/topbar/index.js
@@ -238,8 +238,8 @@ class ProjectDialog extends Component {
                                 ) : (null)
                             }
                             <div class={style.container}>
-                                <div>{project.props.state.data.dappfile.getObj().project.info.title || ""} - </div>
-                                <div>&nbsp;{project.props.state.data.dir}</div>
+                                <div>{project.props.state.data.dir} - </div>
+                                <div>&nbsp;{project.props.state.data.dappfile.getObj().project.info.title || ""}</div>
                             </div>
                             <div class={classNames([style.projSwitcherRowActions, style.container])}>
                                 <button class="btnNoBg" onClick={(e)=>{this.openProjectConfig(e, project)}}>


### PR DESCRIPTION
Change the order of the items in the list to make sure we first render the project name and then the project title. The structure then will be as follows:

{project_name} - {project_title}