### PR TITLE
Open first contract by default when opening a project

### DIFF
--- a/src/components/projecteditor/control/control.js
+++ b/src/components/projecteditor/control/control.js
@@ -261,7 +261,7 @@ export default class Control extends Component {
                 var contract=contracts[index];
 
                 const contractChildChildren=[];
-                var contractChild=this._newItem({title: contract.name+".sol", _index: index, _nrContracts: contracts.length, _key: contract.name+":"+contract.source, render: this._renderContractTitle, icon: <IconContract />, _project: projectItem, _contract: contract, type: "file", type2: "contract", file: contract.source, toggable: true, state:{_tag: 0, open:false, children: contractChildChildren}});
+                var contractChild=this._newItem({title: contract.name+".sol", _index: index, _nrContracts: contracts.length, _key: contract.name+":"+contract.source, render: this._renderContractTitle, icon: <IconContract />, _project: projectItem, _contract: contract, type: "file", type2: "contract", file: contract.source, toggable: true, state:{_tag: 0, open: index == 0 ? true : false, children: contractChildChildren}});
 
                 var contractConfig=this._newItem({title: "Configure", _contract: contract.name, _project: projectItem, type: "contract", type2: "configure", onClick: this._openItem, icon: <IconConfigure />, state: {_tag: 1}});
                 var contractInteract=this._newItem({title: "Interact", _parentItem: contractChild, _contract: contract.name, _project: projectItem, type: "contract", type2: "interact", onClick: this._openItem, icon: <IconInteract /> , state: {_tag: 2}});


### PR DESCRIPTION
Simply open the first contract by default when opening a project for the first time. The reason to do this is that when creating the project you will give visual guidance on the actions to be taken for the contract. 

