### PR TITLE
Updated the "New Project" flow to first select a template

### DIFF
--- a/src/components/newdapp/index.js
+++ b/src/components/newdapp/index.js
@@ -94,6 +94,7 @@ export default class NewDapp extends Component {
     }
 }
 
+
 NewDapp.proptypes = {
     modal: Proptypes.object.isRequired,
     functions: Proptypes.object.isRequired,

--- a/src/components/newdapp/index.js
+++ b/src/components/newdapp/index.js
@@ -16,8 +16,8 @@
 
 import { h, Component } from 'preact';
 import Proptypes from 'prop-types';
-import Step1 from './step1';
-import Step2 from './step2';
+import SelectedTemplate from './selectTemplate';
+import ProjectDetails from './projectDetails';
 import Templates from '../templates';
 
 export default class NewDapp extends Component {
@@ -65,14 +65,14 @@ export default class NewDapp extends Component {
         let step;
         switch (this.state.currentStep) {
             case 1:
-                step = <Step1
+                step = <ProjectDetails
                             projectName={this.state.projectInfo ? this.state.projectInfo.name : ""}
                             projectTitle={this.state.projectInfo ? this.state.projectInfo.title : ""}
                             onStep1Done={this.onStep1DoneHandle}
                             onCloseClickHandle={this.onCloseClickHandle}/>;
                 break;
             case 2:
-                step = <Step2
+                step = <SelectedTemplate
                             categories={Templates.categories}
                             templates={Templates.templates}
                             onTemplateSelected={this.onTemplateSelectedHandle}
@@ -80,7 +80,7 @@ export default class NewDapp extends Component {
                             onCloseClickHandle={this.onCloseClickHandle}/>;
                 break;
             default:
-                step = <Step1 onStep1Done={this.onStep1DoneHandle}/>;
+                step = <AddProjectDetails onStep1Done={this.onStep1DoneHandle}/>;
                 break;
         }
 

--- a/src/components/newdapp/index.js
+++ b/src/components/newdapp/index.js
@@ -94,7 +94,6 @@ export default class NewDapp extends Component {
     }
 }
 
-
 NewDapp.proptypes = {
     modal: Proptypes.object.isRequired,
     functions: Proptypes.object.isRequired,

--- a/src/components/newdapp/index.js
+++ b/src/components/newdapp/index.js
@@ -23,15 +23,8 @@ import Templates from '../templates';
 export default class NewDapp extends Component {
 
     state = {
-        projectInfo: null,
+        selectedTemplate: null,
         currentStep: 1,
-    }
-
-    onStep1DoneHandle = (projectInfo) => {
-        this.setState({
-            currentStep: 2,
-            projectInfo: projectInfo
-        });
     }
 
     onCloseClickHandle = () => {
@@ -39,15 +32,23 @@ export default class NewDapp extends Component {
     }
 
     onTemplateSelectedHandle = (selectedTemplate) => {
-        var dappfile = selectedTemplate.dappfile;
+        this.setState({
+            currentStep: 2,
+            selectedTemplate: selectedTemplate
+        })
+    }
+
+    onProjectDetailsDone = (projectInfo) => {
+        var dappfile = this.state.selectedTemplate.dappfile;
 
         // Make sure we include the info of the current project in the dappFile, in order to do not break anything in the app...
-        const project = { info: this.state.projectInfo }
+        const project = { info: projectInfo }
         dappfile.project = project;
 
-        const files = selectedTemplate.files;
+        const files = this.state.selectedTemplate.files;
 
-        this.props.backend.saveProject(this.state.projectInfo.name, { dappfile: dappfile }, o => this.props.cb(o.status, o.code), true, files);
+        this.props.backend.saveProject(projectInfo.name, { dappfile: dappfile }, o => this.props.cb(o.status, o.code), true, files);
+
         this.closeModal();
     }
 
@@ -65,19 +66,20 @@ export default class NewDapp extends Component {
         let step;
         switch (this.state.currentStep) {
             case 1:
-                step = <ProjectDetails
-                            projectName={this.state.projectInfo ? this.state.projectInfo.name : ""}
-                            projectTitle={this.state.projectInfo ? this.state.projectInfo.title : ""}
-                            onStep1Done={this.onStep1DoneHandle}
-                            onCloseClickHandle={this.onCloseClickHandle}/>;
-                break;
-            case 2:
                 step = <SelectedTemplate
                             categories={Templates.categories}
                             templates={Templates.templates}
                             onTemplateSelected={this.onTemplateSelectedHandle}
-                            onBackPress={this.pop}
-                            onCloseClickHandle={this.onCloseClickHandle}/>;
+                            onBackPress={this.closeModal}
+                            onCloseClick={this.onCloseClickHandle}/>;
+                break;
+            case 2:
+                step = <ProjectDetails
+                            projectName={this.state.projectInfo ? this.state.projectInfo.name : ""}
+                            projectTitle={this.state.projectInfo ? this.state.projectInfo.title : ""}
+                            onProjectDetailsDone={this.onProjectDetailsDone}
+                            onCloseClick={this.onCloseClickHandle}
+                            onBackClick={this.pop}/>;
                 break;
             default:
                 step = <AddProjectDetails onStep1Done={this.onStep1DoneHandle}/>;

--- a/src/components/newdapp/projectDetails/index.js
+++ b/src/components/newdapp/projectDetails/index.js
@@ -61,12 +61,16 @@ export default class ProjectDetails extends Component {
         }
 
         if (this.validateInputs()) {
-            this.props.onStep1Done({ name: this.state.projectName, title: this.state.projectTitle });
+            this.props.onProjectDetailsDone({ name: this.state.projectName, title: this.state.projectTitle });
         }
     };
 
     onCloseClickHandle = () => {
-        this.props.onCloseClickHandle();
+        this.props.onCloseClick();
+    };
+
+    onBackClickHandle = () => {
+        this.props.onBackClick();
     };
 
     handleNameChange = changeEvent => {
@@ -118,8 +122,8 @@ export default class ProjectDetails extends Component {
                         </div>
                     </div>
                     <div class={style.footer}>
-                        <button onClick={this.onCloseClickHandle} class="btn2 noBg mr-2">Cancel</button>
-                        <button onClick={this.onNextClickHandle} class="btn2">Next</button>
+                        <button onClick={this.onBackClickHandle} class="btn2 noBg mr-2">Back</button>
+                        <button onClick={this.onNextClickHandle} class="btn2">Create Project</button>
                     </div>
                 </div>
             </div>
@@ -128,6 +132,7 @@ export default class ProjectDetails extends Component {
 }
 
 ProjectDetails.propTypes = {
-    onStep1Done: Proptypes.func.isRequired,
-    onCloseClickHandle: Proptypes.func.isRequired
+    onProjectDetailsDone: Proptypes.func.isRequired,
+    onCloseClick: Proptypes.func.isRequired,
+    onBackClick: Proptypes.func.isRequired
 }

--- a/src/components/newdapp/projectDetails/index.js
+++ b/src/components/newdapp/projectDetails/index.js
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import style from '../style';
 import { IconClose } from '../../icons';
 
-export default class Step1 extends Component {
+export default class ProjectDetails extends Component {
 
     constructor(props) {
         super(props);
@@ -127,7 +127,7 @@ export default class Step1 extends Component {
     }
 }
 
-Step1.propTypes = {
+ProjectDetails.propTypes = {
     onStep1Done: Proptypes.func.isRequired,
     onCloseClickHandle: Proptypes.func.isRequired
 }

--- a/src/components/newdapp/selectTemplate/index.js
+++ b/src/components/newdapp/selectTemplate/index.js
@@ -67,8 +67,8 @@ export default class SelectTemplate extends Component {
         this.props.onTemplateSelected(this.state.templateSelected);
     }
 
-    back = () => {
-        this.props.onBackPress();
+    onCancelClickHandle = () => {
+        this.props.onCloseClick();
     }
 
     onCategorySelected(id) {
@@ -84,7 +84,7 @@ export default class SelectTemplate extends Component {
     }
 
     onCloseClickHandle = () => {
-        this.props.onCloseClickHandle();
+        this.props.onCloseClick();
     };
 
     render() {
@@ -124,8 +124,8 @@ export default class SelectTemplate extends Component {
                         </div>
                     </div>
                     <div class={style.footer}>
-                        <button onClick={this.back} class="btn2 noBg mr-2">Back</button>
-                        <button onClick={this.onCreateProjectHandle} disabled={!templateSelected} class="btn2">Create Project</button>
+                        <button onClick={this.onCancelClickHandle} class="btn2 noBg mr-2">Cancel</button>
+                        <button onClick={this.onCreateProjectHandle} disabled={!templateSelected} class="btn2">Select Template</button>
                     </div>
                 </div>
             </div>
@@ -137,6 +137,5 @@ SelectTemplate.proptypes = {
     categories: Proptypes.array.isRequired,
     templates: Proptypes.array.isRequired,
     onTemplateSelected: Proptypes.func.isRequired,
-    onBackPress: Proptypes.func.isRequired,
-    onCloseClicked: Proptypes.func.isRequired
+    onCloseClick: Proptypes.func.isRequired
 }

--- a/src/components/newdapp/selectTemplate/index.js
+++ b/src/components/newdapp/selectTemplate/index.js
@@ -56,7 +56,7 @@ TemplateLayout.propTypes = {
     onTemplateSelected: Proptypes.func.isRequired
 }
 
-export default class Step2 extends Component {
+export default class SelectTemplate extends Component {
 
     state = {
         categorySelectedId: 0,
@@ -133,7 +133,7 @@ export default class Step2 extends Component {
     }
 }
 
-Step2.proptypes = {
+SelectTemplate.proptypes = {
     categories: Proptypes.array.isRequired,
     templates: Proptypes.array.isRequired,
     onTemplateSelected: Proptypes.func.isRequired,


### PR DESCRIPTION
Update the `New Project` flow to make sure the template selection is the first thing the user sees. These are the reasons: 

1. When creating a templated base project, you first want to check out which possibilities of templates there are before deciding on a name for your specific project. 
2. This way we can promote the available templates to trigger the curiosity of the user before having to require the details of the project creation. 

