### PR TITLE
Increase deployer gas limit

### DIFF
--- a/src/components/projecteditor/deployer.js
+++ b/src/components/projecteditor/deployer.js
@@ -145,7 +145,7 @@ export default class Deployer extends Component {
             endpoint: endpoint,
             network: this.network,
             gasPrice: "0x3B9ACA00", //TODO
-            gasLimit: "0x3b8260", //TODO
+            gasLimit: "0x788B60", //TODO
             recompile: this.recompile,
             redeploy: redeploy,
             contract: contract,


### PR DESCRIPTION
### Description of the Change
This change bumps the default gas limit used for deployment from `3900000` to `7900000`. 

### Alternate Designs
Not applicable.

### Benefits
The original value was set to the maximum block gas limit value observed at the time. The network has evolved since then and the current observable block gas limit is close to 8 million now.

This new value is slightly below the current observable block gas limit in all networks (except Rinkeby, currently in the lower 7000000 bound).

### Possible Drawbacks
Apparently none.

### Verification Process
_Deploy_ output now reads:  
```
Gaslimit=0x788B60, gasPrice=0x3B9ACA00.
```

### Github Issues
Resolves #111 