### PR TITLE
Fixed typo in category crowdfunding

### DIFF
--- a/src/components/templates/index.js
+++ b/src/components/templates/index.js
@@ -28,7 +28,7 @@ export default class Templates {
         },
         {
             "id": 1,
-            "name": "Crowfunding"
+            "name": "Crowdfunding"
         },
         {
             "id": 2,


### PR DESCRIPTION
### Description of the Change
Simply fix a typo in the category name `crowdfunding`, previously spelled as `crowfunding`.

### Possible Drawbacks

None

### Verification Process
Run make to verify with the working solution that the fix is actually introduced in the `SelectTemplate` component. 
