### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -1,5 +1,5 @@
 export const initialState = {
-    version: '1.0.0',
+    version: '1.0.1',
 };
 
 export default function appReducer(state = initialState, action) {


### PR DESCRIPTION
### Description of the Change

Bump to new version containing various bug fixes and improvements:

* Fix: Compiler does not display the error for failure when contract name and filename does not match #104
* Fix: Compiling with warnings breaks interaction page #102
* Fix: Uncensorable newsfeed template contains errors #103
* Improvement: Updated the "New Project" flow to first select a template #108
* Improvement: Increase deployer gas limit #173
* Improvement: Lightning icon in Show Preview window reads as "Recompile" #163
* Fix: Change the compiler's error strings from orange to red #139
* Fix renaming issue #168
* Fix typo in category crowdfunding #174