### PR TITLE
WIP - Update Circle CI configuration to fix constraints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/node:7.10
+# replicating CI bug...
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
### Description of the Change
Update Circle CI configuration to use a newer _node_ docker image version.

### Benefits
This is expected to fix the following error:
```
error eslint-plugin-compat@2.6.1: The engine "node" is incompatible with this module. Expected version ">=8.x".
error Found incompatible module
```

### Possible Drawbacks
This will only impact the small set of tests.

### Verification Process
Depends on Circle CI and automated testing.

### Github Issues
None.