### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,15 @@
 
 ## [current]
 
+* Fix: list changes in CHANGELOG file #178
+* Improvement: limit left side panel width when resizing #170
+* Fix: rendering glitch in Help/General menu #182
+* Fix: items alignment in Files hierarchy #187
+* Improvement: reference tests covering base compile functionality #176
+* Improvement: update Solidity compiler to version 0.4.25 #180
+* Fix: continuous integration base environment to use Node version 8.12 #190
+* Improvement: increase maximum file name length to 255 characters #183
+
 
 ## [1.0.1]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 # Superblocks Lab - Change log
 
-## [current]
+## [1.0.2]
 
 * Fix: list changes in CHANGELOG file #178
 * Improvement: limit left side panel width when resizing #170

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -46,10 +46,12 @@ _version_date=$(date "+%Y-%m-%d")
 # Files to change
 _src_components_app_file="./src/reducers/app.js"
 _src_manifest_file="./src/manifest.json"
+_changelog_file="./CHANGELOG"
 
 # Update files
 sed -i.bak "s/\"version\"\:.*/\"version\": \"${_version_name}\"/" "$_src_manifest_file"
 sed -i.bak "s/.*version\: \'.*/    version\: \'${_version_name}\'\,/" "$_src_components_app_file"
+sed -i.bak "s/\[current\]/\[${_version_name}\]/" "$_changelog_file"
 
 #
 # Cleanup temporary files
@@ -59,4 +61,8 @@ fi
 
 if [ -f "$_src_components_app_file" ]; then
     rm "${_src_components_app_file}.bak"
+fi
+
+if [ -f "$_changelog_file" ]; then
+    rm "${_changelog_file}.bak"
 fi

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -44,12 +44,12 @@ _version_date=$(date "+%Y-%m-%d")
 
 #
 # Files to change
-_src_components_app_file="./src/components/app/app.js"
+_src_components_app_file="./src/reducers/app.js"
 _src_manifest_file="./src/manifest.json"
 
 # Update files
 sed -i.bak "s/\"version\"\:.*/\"version\": \"${_version_name}\"/" "$_src_manifest_file"
-sed -i.bak "s/this\.\_version\=\".*/this\.\_version=\"${_version_name}\"\;/" "$_src_components_app_file"
+sed -i.bak "s/.*version\: \'.*/    version\: \'${_version_name}\'\,/" "$_src_components_app_file"
 
 #
 # Cleanup temporary files

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -1,5 +1,5 @@
 export const initialState = {
-    version: '1.0.1',
+    version: '1.0.2',
 };
 
 export default function appReducer(state = initialState, action) {


### PR DESCRIPTION
### Description of the Change

Bump to new version containing various bug fixes and improvements:
* Fix: list changes in CHANGELOG file #178
* Improvement: limit left side panel width when resizing #170
* Fix: rendering glitch in Help/General menu #182
* Fix: items alignment in Files hierarchy #187
* Improvement: reference tests covering base compile functionality #176
* Improvement: update Solidity compiler to version 0.4.25 #180
* Fix: continuous integration base environment to use Node version 8.12 #190
* Improvement: increase maximum file name length to 255 characters #183