### PR TITLE
Changed telegram for discord (community)

### DIFF
--- a/src/components/contactContainer/ContactContainer.js
+++ b/src/components/contactContainer/ContactContainer.js
@@ -19,7 +19,7 @@ import style from './style';
 import {
     IconGithub,
     IconTwitter,
-    IconTelegram
+    IconDiscord
 } from '../icons';
 
 export default class ContactContainer extends Component {
@@ -28,14 +28,14 @@ export default class ContactContainer extends Component {
         return (
             <div class={style.container}>
                 <div style="display: inline-block">
-                    <a href="https://twitter.com/getsuperblocks" target="_blank" rel="noopener noreferrer" class={style.contactIcon}>
+                    <a href="https://twitter.com/getsuperblocks" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks' Twitter">
                         <IconTwitter />
                     </a>
-                    <a href="https://github.com/SuperblocksHQ/superblocks-lab" target="_blank" rel="noopener noreferrer" class={style.contactIcon}>
+                    <a href="https://github.com/SuperblocksHQ/superblocks-lab" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks Lab Github">
                         <IconGithub />
                     </a>
-                    <a href="https://t.me/GetSuperblocks" target="_blank" rel="noopener noreferrer" class={style.contactIcon}>
-                        <IconTelegram />
+                    <a href="https://discord.gg/RZundp" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks' Community (Discord)">
+                        <IconDiscord />
                     </a>
                 </div>
                 <div class={style.version}>

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -38,7 +38,7 @@ import iconClose from '@fortawesome/fontawesome-free-solid/faTimes';
 import iconQuestionCircle from '@fortawesome/fontawesome-free-regular/faQuestionCircle';
 import iconTwitter from '@fortawesome/fontawesome-free-brands/faTwitter';
 import iconGithub from '@fortawesome/fontawesome-free-brands/faGithub';
-import iconTelegram from '@fortawesome/fontawesome-free-brands/faTelegram';
+import iconDiscord from '@fortawesome/fontawesome-free-brands/faDiscord';
 import iconLock from '@fortawesome/fontawesome-free-solid/faLock';
 import iconLockOpen from '@fortawesome/fontawesome-free-solid/faLockOpen';
 import iconPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
@@ -121,5 +121,5 @@ export const IconWhatsNew = ({...props}) => <IconImg src={'/static/img/icon-what
 // External services
 export const IconTwitter = ({...props}) => <FaIcon icon={iconTwitter} {...props} />;
 export const IconGithub = ({...props}) => <FaIcon icon={iconGithub} {...props} />;
-export const IconTelegram = ({...props}) => <FaIcon icon={iconTelegram} {...props}/>;
+export const IconDiscord = ({...props}) => <FaIcon icon={iconDiscord} {...props}/>;
 

--- a/src/components/topbar/index.js
+++ b/src/components/topbar/index.js
@@ -12,7 +12,7 @@ import {
     IconHelp,
     IconProjectSelector,
     IconDropdown,
-    IconTelegram,
+    IconDiscord,
     IconCheck
 } from '../icons';
 
@@ -34,9 +34,9 @@ const HelpDropdownDialog = () => (
             </li>
             <li>
                 <div class={style.container}>
-                    <a href="https://t.me/GetSuperblocks" target="_blank" rel="noopener noreferrer">Join our Community!</a>
-                    <span class={style.telegramIcon}>
-                        <IconTelegram color="#0088cc"/>
+                    <a href="https://discord.gg/RZundp" target="_blank" rel="noopener noreferrer" title="Superblocks' community">Join our Community!</a>
+                    <span class={style.communityIcon}>
+                        <IconDiscord color="#7289DA"/>
                     </span>
                 </div>
 


### PR DESCRIPTION
### Description of the Change

As we are setting up a community focused communication tool, we are moving from Telegram to Discord to do so. This PRs simply updates all the references we had to Telegram to point to the newly created Discord server. 

### Benefits

Well is not part of the scope of the PR to judge the benefits of Discord vs Telegram :D 


### Verification Process
1. On the left control panel, it should display the Discord icon, and when clicked, it should take you to the Superblocks Discord server. 

2. Inside the Help dialog (top right), the dropdown menu should display a Discord icon and when clicked, it should take you to Superblocks Discord server. 
