### PR TITLE
Updated Discord link to use a permanent one

### DIFF
--- a/src/components/contactContainer/ContactContainer.js
+++ b/src/components/contactContainer/ContactContainer.js
@@ -34,7 +34,7 @@ export default class ContactContainer extends Component {
                     <a href="https://github.com/SuperblocksHQ/superblocks-lab" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks Lab Github">
                         <IconGithub />
                     </a>
-                    <a href="https://discord.gg/RZundp" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks' Community (Discord)">
+                    <a href="https://discord.gg/6Cgg2Dw" target="_blank" rel="noopener noreferrer" class={style.contactIcon} title="Superblocks' Community (Discord)">
                         <IconDiscord />
                     </a>
                 </div>

--- a/src/components/topbar/index.js
+++ b/src/components/topbar/index.js
@@ -34,7 +34,7 @@ const HelpDropdownDialog = () => (
             </li>
             <li>
                 <div class={style.container}>
-                    <a href="https://discord.gg/RZundp" target="_blank" rel="noopener noreferrer" title="Superblocks' community">Join our Community!</a>
+                    <a href="https://discord.gg/6Cgg2Dw" target="_blank" rel="noopener noreferrer" title="Superblocks' community">Join our Community!</a>
                     <span class={style.communityIcon}>
                         <IconDiscord color="#7289DA"/>
                     </span>


### PR DESCRIPTION
### Description of the Change

Updated Discord's link to use a permanent one instead (the one currently in the tool was actually a temporary link)

### Verification Process

1. Launch Discord through the icon in the left side control panel 
2. Launch Discord through the dropdown menu on the top right `Help` action 