### PR TITLE
Fix typo - Issue #181

### DIFF
--- a/src/components/projecteditor/editor-account.js
+++ b/src/components/projecteditor/editor-account.js
@@ -282,7 +282,7 @@ export default class AccountEditor extends Component {
         }
         else {
             // Check for external web3 provider
-            if (this.form.walletTyp == "external") {
+            if (this.form.walletType == "external") {
                 if (this.form.isLocked) {
                     return (
                         <p>


### PR DESCRIPTION
Editing account shows MetaMask accounts as private wallet accounts #181


<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Fixed typo in editor-account.js
"Unlock" button is now displayed correctly.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Compiled local dev build and tested.

1. Edit account
2. Click on a public network
3. See that the "Unlock" button does not show and that "Metamask is locked. Unlock Metamask to see address and balance of this account.." is displayed.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Github Issues

This fixes #181
