### PR TITLE
Fix bug about non existing contracts in the dappfile. issue #272

### DIFF
--- a/src/components/projecteditor/control/item/contractItem.js
+++ b/src/components/projecteditor/control/item/contractItem.js
@@ -107,6 +107,10 @@ export default class ContractItem extends FileItem {
                     if (obj) {
                         this.getProject().getItemByPath(obj[0].split('/'), this.getProject()).then( (fileItem) => {
                             fileItem.mv(obj[1]).then(fn);
+                        })
+                        .catch( (e) => {
+                            console.log('Error: could not move file', obj[0], obj[1]);
+                            fn();
                         });
                     }
                     else {
@@ -170,6 +174,7 @@ export default class ContractItem extends FileItem {
      */
     notifyMoved = (oldPath, cb) => {
         return new Promise( (resolve) => {
+            this.props.state.source = this.getFullPath();  // We need to keep the items source up to date with the actual file path.
             this.getProject().moveContract(oldPath, this.getFullPath(), resolve);
             this._moveContractBuildFiles(oldPath, this.getSource());
         });

--- a/src/components/projecteditor/control/item/item.js
+++ b/src/components/projecteditor/control/item/item.js
@@ -163,14 +163,15 @@ export default class Item {
         this.props.state.key = newKey;
     };
 
-    _copyState = (target, source) => {
+    _copyState = (target, source, keyName) => {
+        keyName = keyName || 'key';
         var ret = [];
         for (var index = 0; index < target.length; index++) {
             var targetChild = target[index];
             for (var index2 = 0; index2 < source.length; index2++) {
                 var sourceChild = source[index2];
                 // Compare properties.
-                if (this._cmpItem(targetChild.props, sourceChild.props)) {
+                if (this._cmpItem(targetChild.props, sourceChild.props, keyName)) {
                     // Copy over original state object to new item.
                     // But copy back all value which are double underscored, those we actually want the latest properties of,
                     // such as `__parent`, which will refer to the newly created parent item.
@@ -191,8 +192,8 @@ export default class Item {
         }
     };
 
-    _cmpItem = (item1, item2) => {
-        return item1.state.key === item2.state.key;
+    _cmpItem = (item1, item2, keyName) => {
+        return item1.state[keyName] === item2.state[keyName];
     };
 
     redraw = () => {

--- a/src/components/projecteditor/control/item/projectItem.js
+++ b/src/components/projecteditor/control/item/projectItem.js
@@ -372,9 +372,13 @@ export default class ProjectItem extends Item {
                 children.push(childItem);
             }
             // Copy over the state from cached children to new children, so they appear to be the same (but the objects are new).
+            // NOTE: we are using the key 'source' for comparing these items with eachother because this is a flat list
+            // and the actually file structure is an hierarchical tree where key is just the filename, but since we have
+            // a flat list here we need to key of the full path.
             contractsItem._copyState(
                 children,
-                contractsItem.props.state._children || []
+                contractsItem.props.state._children || [],
+                'source'
             );
 
             // Save cache generated.


### PR DESCRIPTION
### Description of the Change
This fixes some bugs when it comes to handling the file tree structure with contracts and making sure only existing contracts are in the Dappfile.json. It is a delicate procedure about keeping everything up to date when renaming, moving around contracts.

### Benefits
Dappfile.json actually up to date as it should be, for these cases in #272.

### Verification Process
See #272.

### Github Issues
#272 
