### PR TITLE
Fix bump_version helper script and bump version to 1.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Superblocks Lab - Change log
 
+## [1.4.0]
+
++ Addition: Anonymous amplitude tracking #305
+* Improvement: Minor UI updates #290
+* Change: List of upcoming features #309
+* Fix: Local storage quota full when performing compiler operations #283
+* Fix: Compiler's replyMessage gets called multiple times #279
+* Fix: Postinstall script error on Windows #301
+
+
 ## [1.3.0]
 
 + Addition: Integrate OpenZeppelin smart contracts #253

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -44,7 +44,7 @@ _version_date=$(date "+%Y-%m-%d")
 
 #
 # Files to change
-_src_components_app_file="./src/reducers/app.js"
+_src_components_app_file="./src/reducers/app.reducer.js"
 _src_manifest_file="./src/manifest.json"
 _changelog_file="./CHANGELOG"
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/src/reducers/app.reducer.js
+++ b/src/reducers/app.reducer.js
@@ -1,5 +1,5 @@
 export const initialState = {
-    version: '1.3.0',
+    version: '1.4.0',
 };
 
 export default function appReducer(state = initialState, action) {


### PR DESCRIPTION
### Description of the Change

Bump new version containing the following changes:

* Addition: Anonymous amplitude tracking #305
* Improvement: Minor UI updates #290
* Change: List of upcoming features #309
* Fix: Local storage quota full when performing compiler operations #283             
* Fix: Compiler's replyMessage gets called multiple times #279
* Fix: Postinstall script error on Windows #301