### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 # Superblocks Lab - Change log
 
+## [1.4.1]
+
+* Improvement: App view running on separate subdomain #303
+* Improvement: Reduce initial loading time #306
+* Fix: Incorrect tuple rendering output in the Interact window #308
+* Fix: Unable to close split window #291
+
+
 ## [1.4.0]
 
 + Addition: Anonymous amplitude tracking #305

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/src/reducers/app.reducer.js
+++ b/src/reducers/app.reducer.js
@@ -1,5 +1,5 @@
 export const initialState = {
-    version: '1.4.0',
+    version: '1.4.1',
 };
 
 export default function appReducer(state = initialState, action) {


### PR DESCRIPTION
### Description of the Change

Bump new version containing the following changes:
* Improvement: App view running on separate subdomain #303
* Improvement: Reduce initial loading time #306
* Fix: Incorrect tuple rendering output in the Interact window #308
* Fix: Unable to close split window #291