### PR TITLE
fix smart contract import missing from file browser

### DIFF
--- a/src/components/projecteditor/control/item/fileItem/directoryEntry.js
+++ b/src/components/projecteditor/control/item/fileItem/directoryEntry.js
@@ -20,6 +20,7 @@ import {
     IconEdit,
     IconAddFile,
     IconAddFolder,
+    IconImportFile
 } from '../../../../icons';
 import style from '../../style.less';
 import { DropdownContainer } from '../../../../common';
@@ -34,6 +35,7 @@ export class DirectoryEntry extends Component {
             title,
             angleClicked,
             clickNewFile,
+            clickImportFile,
             clickNewFolder,
             clickRenameFile,
             clickDeleteFile,
@@ -50,6 +52,12 @@ export class DirectoryEntry extends Component {
                         <IconAddFile />
                     </div>
                     Create File
+                </div>
+                <div onClick={clickImportFile}>
+                    <div className={style.icon} >
+                        <IconImportFile />
+                    </div>
+                    Import File
                 </div>
                 <div onClick={clickNewFolder}>
                     <div className={style.icon} >


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
I have recently seen that the "Import File" option was missing from the Context menu. For this reasion I have added the "File Import" to the directoryEntry file. This way the OpenZeppelin import is accessible again.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->



<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Import File is accessible again.
<!-- What benefits will be realized by the code change? -->



<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Right clicking on any folder outside of the "app" folder brings up a context menu, which now contains the Import file entry as well.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->



<!-- Enter any applicable Issues here -->
