### PR TITLE
Fix yarn start 

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -4,8 +4,11 @@ const paths = require('../config/paths');
 function buildWeb3Provider() {
     let fileContent = fs.readFileSync(paths.appSrc + '/components/superprovider/web3provider.js', { encoding: 'utf-8' });
     fileContent = fileContent.replace(/ORIGIN/g, "'" + process.env.ORIGIN + "'");
-    fs.mkdirSync(paths.appSrc + '/components/superprovider/dist');
-    fs.writeFileSync(paths.appSrc + '/components/superprovider/dist/web3provider.js', fileContent, { encoding: 'utf-8' });
+    let distPath = paths.appSrc + '/components/superprovider/dist';
+    if(!fs.existsSync(distPath)) {
+        fs.mkdirSync(distPath);
+    }
+    fs.writeFileSync(distPath + '/web3provider.js', fileContent, { encoding: 'utf-8' });
 }
 
 module.exports = {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -4,6 +4,7 @@ const paths = require('../config/paths');
 function buildWeb3Provider() {
     let fileContent = fs.readFileSync(paths.appSrc + '/components/superprovider/web3provider.js', { encoding: 'utf-8' });
     fileContent = fileContent.replace(/ORIGIN/g, "'" + process.env.ORIGIN + "'");
+    fs.mkdirSync(paths.appSrc + '/components/superprovider/dist');
     fs.writeFileSync(paths.appSrc + '/components/superprovider/dist/web3provider.js', fileContent, { encoding: 'utf-8' });
 }
 


### PR DESCRIPTION
### Description of the Change

Fix `yarn start`. When starting clean, the `dist` folder was not there, causing the problem in the start.js code when building the web3provider. 

### Verification Process

1. Checkout master per example, remove the `dist` folder and try to run the app with `yarn start`. You will get an error. 
2. Check out this branch, and run `yarn start` again. 
3. Enjoy!
