### PR TITLE
Fix a bug with pane resizing after moving between tabs and switching side panels

### DIFF
--- a/src/components/projecteditor/ProjectEditor.js
+++ b/src/components/projecteditor/ProjectEditor.js
@@ -106,7 +106,7 @@ export default class ProjectEditor extends Component {
 
     onPanesSizeChange() {
         if (this.props.router.panes) {
-            this.props.router.panes.redraw(true);
+            this.props.router.panes.redraw(false);
         }
     }
 

--- a/src/components/projecteditor/panes.js
+++ b/src/components/projecteditor/panes.js
@@ -284,6 +284,9 @@ class Panes extends Component {
                 if (paneObj) {
                     paneObj.style.display = 'block';
                 }
+                // visible pane should be drawn because of side panels
+                // which state is unknown to the pane
+                setTimeout(() => { pane.redraw(); }, 5);
             } else {
                 var paneObj = document.getElementById(key);
                 if (paneObj) paneObj.style.display = 'none';


### PR DESCRIPTION
### Description

* Open README.MD
* Open dapp.json
* Open side panel
* Navigate to README.MD

Actual result: editor window is empty
Expected result: README.MD content is displayed