### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Superblocks Lab - Change log
 
+## [1.6.1]
+
+* Fix: Suppress right click on some filesystem items #353
+* Fix: yarn start not working when starting clean  #354
+* Fix: Pane resizing after moving between tabs and switching side panels #355
+
+
 ## [1.6.0]
 
 + Addition: Support for Metamask provider.enable() security functionality #304

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/src/reducers/app.reducer.js
+++ b/src/reducers/app.reducer.js
@@ -15,7 +15,7 @@
 // along with Superblocks Lab.  If not, see <http://www.gnu.org/licenses/>.
 
 export const initialState = {
-    version: '1.6.0',
+    version: '1.6.1',
 };
 
 export default function appReducer(state = initialState, action) {


### PR DESCRIPTION
### Description of the Change

Bump new version containing the following changes:

* Fix: Suppress right click on some filesystem items #353
* Fix: yarn start not working when starting clean  #354
* Fix: Pane resizing after moving between tabs and switching side panels #355