### PR TITLE
Fix account name not updating after account change

### DIFF
--- a/src/components/networkAccountSelector/accountSelector.js
+++ b/src/components/networkAccountSelector/accountSelector.js
@@ -76,6 +76,7 @@ export class AccountSelector extends Component {
         const accountsItem = project.getHiddenItem('accounts');
 
         const account = accountsItem.getChildren()[index];
+        if(!account) { return; }
         const isCurrent = account.getName() === project.getAccount();
 
         if (isCurrent) {
@@ -189,7 +190,8 @@ export class AccountSelector extends Component {
     render() {
         const project = this.props.router.control.getActiveProject();
         if (!project) { return (<div/>); }
-        const account = project.getAccount();
+        const { selectedAccount } = this.props;
+        const account = selectedAccount ? selectedAccount.name : project.getAccount();
         const { accountType, isLocked, network, address } = this.accountType();
         if (!network) { return (<div/>); }
         var accountIcon;

--- a/src/components/networkAccountSelector/index.js
+++ b/src/components/networkAccountSelector/index.js
@@ -37,7 +37,7 @@ class NetworkAccountSelector extends Component {
                     </div>
 
                     <div className={style.actionWrapper}>
-                        <AccountSelector {...this.props} onAccountSelected={onAccountSelected} selectedEnvironment={selectedProject.selectedEnvironment.name} />
+                        <AccountSelector {...this.props} selectedAccount={selectedAccount} onAccountSelected={onAccountSelected} selectedEnvironment={selectedProject.selectedEnvironment.name} />
                     </div>
                 </div>
             </OnlyIf>


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

Fix account name which wasn't updating correctly when you change account.


### What was the Issue
1. Change to `Ropsten` network (or any different test network)
2. Try to change Default account to different one
3. Name is not updating in account selector

Lab 1.6.1

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Try the same steps as above. Should work correctly.