### PR TITLE
Add error checking before referencing web3 object

### DIFF
--- a/src/epics/projects/environmentUpdate.epic.js
+++ b/src/epics/projects/environmentUpdate.epic.js
@@ -38,7 +38,8 @@ export const environmentUpdateEpic = (action$, state$) => action$.pipe(
         previewService.setEnvironment(selectedEnvironment);
 
         // enable metamask
-        if (selectedEnvironment.name !== Networks.browser.name &&
+        if (typeof web3 !== 'undefined' &&
+            selectedEnvironment.name !== Networks.browser.name &&
             selectedEnvironment.name !== Networks.custom.name) {
             return from(web3.currentProvider.enable()).pipe(
                 // do nothing if user gives access to metamask


### PR DESCRIPTION
### Description of the Change

Prevent access to unavailable `web3` object when selecting a external network without the _MetaMask_ extension. In cases where _MetaMask_ extension is either disabled or not installed, the `web3` object is `undefined`.

### Verification Process
Same as described in issue #366:
1. Create or open an existing project
2. Select an external network e.g. _Ropsten_
3. Observe the error in the browser console

### Github Issues

Resolves #366 
