### PR TITLE
Bump version to 1.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Superblocks Lab - Change log
 
+## [1.7.1]
+
+* Fix: Downloaded dapp set to external network won't work #391
+
+
 ## [1.7.0]
 
 + Addition: TypeScript support #342

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "orientation": "portrait",
   "icons": [ ],
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/src/reducers/app.reducer.ts
+++ b/src/reducers/app.reducer.ts
@@ -18,7 +18,7 @@ import { AnyAction } from 'redux';
 import { appActions } from '../actions';
 
 export const initialState = {
-    version: '1.7.0',
+    version: '1.7.1',
     isEmbeddedMode: false
 };
 


### PR DESCRIPTION
### Description of the Change

Bump new version containing the following changes:

* Fix: Downloaded dapp set to external network won't work #391